### PR TITLE
custom driver for Adobe DTM metrics

### DIFF
--- a/addon/metrics-adapters/dynamic-tag-manager.js
+++ b/addon/metrics-adapters/dynamic-tag-manager.js
@@ -1,0 +1,116 @@
+import Ember from 'ember';
+import canUseDOM from '../utils/can-use-dom';
+import objectTransforms from '../utils/object-transforms';
+import BaseAdapter from './base';
+
+const {
+  assert,
+  get,
+  set
+} = Ember;
+const {
+  compact
+} = objectTransforms;
+
+export default BaseAdapter.extend({
+
+  eventQueue: [],
+
+  toStringExtension() {
+    return 'DynamicTagManager';
+  },
+
+  init  () {
+    const config = get(this, 'config');
+    const { src } = config;
+
+    assert(`[ember-metrics] You must pass a valid \`src\` to the ${this.toString()} adapter`, src);
+    set(this, 'dtmSrc', src);
+
+    set(this, 'dataLayerNameString', config['dataLayerName'] || 'dtmDataLayer');
+    window[get(this, 'dataLayerNameString')] = {};
+
+    if (canUseDOM) {
+      /* jshint ignore:start */
+      let script = document.createElement("script");
+      script.src = get(this, 'dtmSrc');
+      script.async = true;
+      document.getElementsByTagName('head')[0].appendChild(script);
+      /* jshint ignore:end */
+    }
+
+    this.checkForQueue();
+  },
+
+  pushAndCheck(dtmEvent) {
+    this.eventQueue.push(dtmEvent);
+    this.checkForQueue();
+  },
+
+  checkForQueue() {
+
+    if (this.get('eventQueue').length) {
+      if (this.isSatelliteDefined()) {
+        this.sendEvents();
+      } else {
+        Ember.run.later(() => {
+          this.checkForQueue();
+        }, 50);
+      }
+    }
+  },
+
+  sendEvents() {
+    this.get('eventQueue').forEach((event) => {
+      for (var key of Object.keys(event)) {
+        window[get(this, 'dataLayerNameString')][key] = event[key];
+      }
+      window._satellite.track(event['event']);
+    });
+    this.set('eventQueue', []);
+  },
+
+  dtmObject(compactedOptions) {
+
+    const dtmEvent = {'event': compactedOptions['event']};
+    delete compactedOptions['event'];
+    for (let key in compactedOptions) {
+      dtmEvent[`${key}`] = compactedOptions[key];
+    }
+    return dtmEvent;
+
+  },
+
+  isSatelliteDefined() {
+    if (typeof(window._satellite) === "object") {
+      return true;
+    } else {
+      return false;
+    }
+  },
+
+  trackEvent(options = {}) {
+    const dtmEvent = this.dtmObject(compact(options));
+    this.pushAndCheck(dtmEvent);
+    return dtmEvent;
+  },
+
+  pushPayload(payload) {
+    for (var key of Object.keys(payload)) {
+      window[get(this, 'dataLayerNameString')][key] = payload[key];
+    }
+  },
+
+  trackPage(options = {}) {
+    const dtmEvent = this.dtmObject(compact(options));
+    dtmEvent['event'] = 'vpv';
+    this.pushAndCheck(dtmEvent);
+    return dtmEvent;
+  },
+
+  willDestroy() {
+    delete window['_satellite'];
+    delete window[get(this, 'dataLayerNameString')];
+  }
+
+});

--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -21,6 +21,7 @@ export default BaseAdapter.extend({
 
   init() {
     const config = copy(get(this, 'config'));
+    console.log(config);
     const { id } = config;
 
     assert(`[ember-metrics] You must pass a valid \`id\` to the ${this.toString()} adapter`, id);

--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -21,7 +21,6 @@ export default BaseAdapter.extend({
 
   init() {
     const config = copy(get(this, 'config'));
-    console.log(config);
     const { id } = config;
 
     assert(`[ember-metrics] You must pass a valid \`id\` to the ${this.toString()} adapter`, id);

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -19,7 +19,7 @@ module.exports = function(environment) {
     },
 
     'ember-metrics': {
-      includeAdapters: ['segment', 'google-tag-manager', 'piwik']
+      includeAdapters: ['segment', 'google-tag-manager', 'piwik', 'dynamic-tag-manager']
     },
 
     metricsAdapters: [
@@ -44,6 +44,14 @@ module.exports = function(environment) {
         // environments: ['all'],
         config: {
           appId: 'def1abc2'
+        }
+      },
+      {
+        // if `environments` is undefined, it defaults to all
+        name: 'DynamicTagManager',
+        // environments: ['all'],
+        config: {
+          src: '//path.com/to.src.js'
         }
       },
       {

--- a/tests/unit/metrics-adapters/dynamic-tag-manager-test.js
+++ b/tests/unit/metrics-adapters/dynamic-tag-manager-test.js
@@ -1,0 +1,18 @@
+import { moduleFor, test } from 'ember-qunit';
+import sinon from 'sinon';
+
+let sandbox, config;
+moduleFor('ember-metrics@metrics-adapter:dynamic-tag-manager', 'dynamic-tag-manager adapter', {
+  beforeEach() {
+    sandbox = sinon.sandbox.create();
+    config = {
+      src: '//path.com/to.src.js'
+    };
+  }
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  var adapter = this.subject({ config });
+  assert.ok(adapter);
+});

--- a/tests/unit/metrics-adapters/dynamic-tag-manager-test.js
+++ b/tests/unit/metrics-adapters/dynamic-tag-manager-test.js
@@ -8,11 +8,41 @@ moduleFor('ember-metrics@metrics-adapter:dynamic-tag-manager', 'dynamic-tag-mana
     config = {
       src: '//path.com/to.src.js'
     };
+    window._satellite = { track() {} };
+  },
+  afterEach() {
+    sandbox.restore();
   }
 });
 
-// Replace this with your real tests.
-test('it exists', function(assert) {
-  var adapter = this.subject({ config });
-  assert.ok(adapter);
+test('#trackEvent calls `_satellite.track`', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window._satellite, 'track');
+
+  const event = 'click-button';
+  const eventData = {
+    event,
+    category: 'button',
+    action: 'click',
+    label: 'nav buttons',
+    value: 4
+  };
+
+  const result = adapter.trackEvent(eventData);
+
+  assert.ok(stub.calledWith(event), 'it sends the right argument');
+  assert.deepEqual(result, eventData, 'it returns the right response');
+});
+
+test('#trackPage calls `_satellite.track`', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window._satellite, 'track');
+
+  const event = 'vpv';
+  const eventData = { event };
+
+  const result = adapter.trackPage();
+
+  assert.ok(stub.calledWith(event), 'it sends the right argument');
+  assert.deepEqual(result, eventData, 'it returns the right response');
 });


### PR DESCRIPTION
Hi there, thanks for your hard work on an excellent add on. Over here at DSC we used `ember-metrics` in conjunction with the `Google Tag Manager` adapter, and everything worked great. Our marketing team made the decision to move to `Adobe Metrics`, so we found the need to build a new adapter. 

This is a first pass for you to take a look at; I basically tried to follow the conventions and patterns you had set in your `Google Tag Manager`. 

One thing I was hoping to get a second eye on is the `eventQueue` I set up here. Unfortunately, Adobe's solution (as far as I could tell) doesn't have any sort of a promise or trigger to alert the library has been loaded in, and we ran into a few issues with the library not being ready by the time Ember code was being executed. 

I set up a pretty basic poll-based timer to check the `eventQueue` array for items and then fire off events in succession (see line 50 or so of the driver), but this may not be ideal. Would love a second opinion.

Also, I could use a little help with tests, if you have any suggestions (full disclosure, I'm a little new to the Ember game and whole Javascript unit testing thing).

Anyways, take a look and hopefully this is something helpful for someone down the road.
