### PR TITLE
Fixes #102, don't prepend all keys with "event"

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,13 @@ contentSecurityPolicy: {
 }
 ```
 
-## Usage
+## Track route changes:
 
-In order to use the addon, you must first [configure](#configuration) it, then inject it into any Object registered in the container that you wish to track. For example, you can call a `trackPage` event across all your analytics services whenever you transition into a route, like so:
+In order to use the addon, you must first [configure](#configuration)
+it, then inject it into any Object registered in the container that
+you wish to track. For example, you can call a `trackPage` event across
+ all your analytics services whenever you transition into a route,
+ like so:
 
 ```js
 // app/router.js
@@ -193,6 +197,16 @@ If you wish to only call a single service, just specify it's name as the first a
 
 metrics.trackPage('GoogleAnalytics', {
   title: 'My Awesome App'
+});
+```
+
+### Track events:
+```js
+metrics.trackEvent({
+  category: 'Video',
+  action: 'Play',
+  label: 'Name of video', 
+  value: 2
 });
 ```
 

--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -55,21 +55,18 @@ export default BaseAdapter.extend({
   },
 
   trackEvent(options = {}) {
-    const compactedOptions = compact(options);
-    const sendEvent = { hitType: 'event' };
-    let gaEvent = {};
+    let compactedOptions = compact(options);
+    let eventData = { hitType: 'event' };
 
-    if (compactedOptions.nonInteraction) {
-      gaEvent.nonInteraction = compactedOptions.nonInteraction;
-      delete compactedOptions.nonInteraction;
-    }
+    ['category', 'action', 'label', 'value'].forEach((key) => {
+      if (compactedOptions[key] != undefined) {
+        const capitalizedKey = capitalize(key);
+        eventData[`event${capitalizedKey}`] = compactedOptions[key];
+        delete compactedOptions[key];
+      }
+    })
 
-    for (let key in compactedOptions) {
-      const capitalizedKey = capitalize(key);
-      gaEvent[`event${capitalizedKey}`] = compactedOptions[key];
-    }
-
-    const event = assign(sendEvent, gaEvent);
+    const event = assign(eventData, compactedOptions);
     if (canUseDOM) {
       window.ga('send', event);
     }

--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -59,7 +59,7 @@ export default BaseAdapter.extend({
     let eventData = { hitType: 'event' };
 
     ['category', 'action', 'label', 'value'].forEach((key) => {
-      if (compactedOptions[key] != undefined) {
+      if (compactedOptions[key] !== undefined && compactedOptions[key] !== null) {
         const capitalizedKey = capitalize(key);
         eventData[`event${capitalizedKey}`] = compactedOptions[key];
         delete compactedOptions[key];


### PR DESCRIPTION
I'm included the documentation in this PR because it's critical that users know NOT to use the documented GA keys `eventCategory`, `eventAction`, `eventLabel`, and `eventValue`, because the ga adapter does that for you. 

That little example would've saved me so many hours of digging around..
