### PR TITLE
Ability to turn on/off specific Google analytics adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ module.exports = function(environment) {
           // Use verbose tracing of GA events
           trace: environment === 'development',
           // Ensure development env hits aren't sent to GA
-          sendHitTask: environment !== 'development'
+          sendHitTask: environment !== 'development',
+          // optional, true is the default
+          enableOnStart: false,
         }
       },
       {

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ module.exports = function(environment) {
         environments: ['development', 'production'],
         config: {
           id: 'UA-XXXX-Y',
+          // optionally you can provide the name if you like to use multiple GA adapters
+          name: 'MyApplication',
           // Use `analytics_debug.js` in development
           debug: environment === 'development',
           // Use verbose tracing of GA events
           trace: environment === 'development',
           // Ensure development env hits aren't sent to GA
-          sendHitTask: environment !== 'development',
-          // optional, true is the default
-          enableOnStart: false,
+          sendHitTask: environment !== 'development'
         }
       },
       {

--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -9,7 +9,7 @@ const {
   assert,
   get,
   $,
-  String: { capitalize },
+  String: { capitalize }
 } = Ember;
 const { compact } = objectTransforms;
 const assign = Ember.assign || Ember.merge;
@@ -21,26 +21,39 @@ export default BaseAdapter.extend({
 
   init() {
     const config = copy(get(this, 'config'));
-    const { id, sendHitTask, trace } = config;
+    const { id, sendHitTask, trace, enableOnStart } = config;
     let { debug } = config;
+
+    const enabled = (typeof enableOnStart != 'undefined' ? enableOnStart : true);
 
     assert(`[ember-metrics] You must pass a valid \`id\` to the ${this.toString()} adapter`, id);
 
     delete config.id;
 
-    if (debug) { delete config.debug; }
-    if (sendHitTask) { delete config.sendHitTask; }
-    if (trace) { delete config.trace; }
+    if (debug) {
+      delete config.debug;
+    }
+    if (sendHitTask) {
+      delete config.sendHitTask;
+    }
+    if (trace) {
+      delete config.trace;
+    }
+    if (enableOnStart) {
+      delete config.enableOnStart;
+    }
 
     const hasOptions = isPresent(Object.keys(config));
 
-    if (canUseDOM) {
+    if (canUseDOM && enabled) {
 
       /* jshint ignore:start */
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script',`https://www.google-analytics.com/analytics${debug ? '_debug' : ''}.js`,'ga');
+      (function(i, s, o, g, r, a, m) {
+        i.GoogleAnalyticsObject = r; i[r] = i[r] || function() {
+          (i[r].q = i[r].q || []).push(arguments);
+        }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m);
+      })(window, document, 'script', `https://www.google-analytics.com/analytics${debug ? '_debug' : ''}.js`, 'ga');
       /* jshint ignore:end */
 
       if (trace === true) {
@@ -56,7 +69,6 @@ export default BaseAdapter.extend({
       if (sendHitTask === false) {
         window.ga('set', 'sendHitTask', null);
       }
-
     }
   },
 

--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -19,12 +19,14 @@ export default BaseAdapter.extend({
     return 'GoogleAnalytics';
   },
 
+  name() {
+    const config = copy(get(this, 'config'));
+    return typeof config.name === 'undefined' ? this.toStringExtension() : config.name;
+  },
+
   init() {
     const config = copy(get(this, 'config'));
-    const { id, sendHitTask, trace, enableOnStart } = config;
-    let { debug } = config;
-
-    const enabled = (typeof enableOnStart != 'undefined' ? enableOnStart : true);
+    const { id, sendHitTask, trace, debug } = config;
 
     assert(`[ember-metrics] You must pass a valid \`id\` to the ${this.toString()} adapter`, id);
 
@@ -39,14 +41,10 @@ export default BaseAdapter.extend({
     if (trace) {
       delete config.trace;
     }
-    if (enableOnStart) {
-      delete config.enableOnStart;
-    }
 
     const hasOptions = isPresent(Object.keys(config));
 
-    if (canUseDOM && enabled) {
-
+    if (canUseDOM) {
       /* jshint ignore:start */
       (function(i, s, o, g, r, a, m) {
         i.GoogleAnalyticsObject = r; i[r] = i[r] || function() {
@@ -67,7 +65,7 @@ export default BaseAdapter.extend({
       }
 
       if (sendHitTask === false) {
-        window.ga('set', 'sendHitTask', null);
+        window.ga(`${this.name()}.set`, 'sendHitTask', null);
       }
     }
   },
@@ -77,7 +75,7 @@ export default BaseAdapter.extend({
     const { distinctId } = compactedOptions;
 
     if (canUseDOM) {
-      window.ga('set', 'userId', distinctId);
+      window.ga(`${this.name()}.set`, 'userId', distinctId);
     }
   },
 
@@ -103,7 +101,7 @@ export default BaseAdapter.extend({
 
     const event = assign(sendEvent, gaEvent);
     if (canUseDOM) {
-      window.ga('send', event);
+      window.ga(`${this.name()}.send`, event);
     }
 
     return event;
@@ -115,7 +113,7 @@ export default BaseAdapter.extend({
 
     const event = assign(sendEvent, compactedOptions);
     if (canUseDOM) {
-      window.ga('send', event);
+      window.ga(`${this.name()}.send`, event);
     }
 
     return event;

--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -57,14 +57,13 @@ export default Service.extend({
    * @return {Void}
    */
   init() {
-    const adapters = getWithDefault(this, 'options.metricsAdapters', emberArray());
     const owner = getOwner(this);
     owner.registerOptionsForType('ember-metrics@metrics-adapter', { instantiate: false });
     owner.registerOptionsForType('metrics-adapter', { instantiate: false });
     set(this, 'appEnvironment', getWithDefault(this, 'options.environment', 'development'));
     set(this, '_adapters', {});
     set(this, 'context', {});
-    this.activateAdapters(adapters);
+    this.activateAdapters(this._adapterOptions());
     this._super(...arguments);
   },
 
@@ -93,20 +92,49 @@ export default Service.extend({
    * @return {Object} instantiated adapters
    */
   activateAdapters(adapterOptions = []) {
+    this.willDestroy();
+
     const appEnvironment = get(this, 'appEnvironment');
     const cachedAdapters = get(this, '_adapters');
     const activatedAdapters = {};
 
+
     adapterOptions
       .filter((adapterOption) => this._filterEnvironments(adapterOption, appEnvironment))
       .forEach((adapterOption) => {
-        const { name } = adapterOption;
+        const { name, config } = adapterOption;
         const adapter = cachedAdapters[name] ? cachedAdapters[name] : this._activateAdapter(adapterOption);
 
         set(activatedAdapters, name, adapter);
       });
 
     return set(this, '_adapters', activatedAdapters);
+  },
+
+  /**
+   * Activates the given adapter that supports enableOnStart flag
+   *
+   * @method activateAdapter
+   * @param {String} adapterName
+   * @return {Void}
+   */
+  activateAdapter(adapterName) {
+    if ( this._adapterEnableStateWillChange(adapterName, true) ) {
+      this.activateAdapters(this._changeAdapterEnableState(adapterName, true));
+    }
+  },
+
+  /**
+   * Deactives the given adapter that supports enableOnStart flag
+   *
+   * @method deactivateAdapter
+   * @param {String} adapterName
+   * @return {Void}
+   */
+  deactivateAdapter(adapterName) {
+    if ( this._adapterEnableStateWillChange(adapterName, false) ) {
+      this.activateAdapters(this._changeAdapterEnableState(adapterName, false));
+    }
   },
 
   /**
@@ -118,7 +146,7 @@ export default Service.extend({
    * @return {Void}
    */
   invoke(methodName, ...args) {
-    if (!get(this, 'enabled')) { return; }
+    if ( !get(this, 'enabled') ) { return; }
 
     const cachedAdapters = get(this, '_adapters');
     const allAdapterNames = keys(cachedAdapters);
@@ -144,6 +172,8 @@ export default Service.extend({
     for (let adapterName in cachedAdapters) {
       get(cachedAdapters, adapterName).destroy();
     }
+
+    set(this, '_adapters', {});
   },
 
   /**
@@ -159,6 +189,53 @@ export default Service.extend({
     assert(`[ember-metrics] Could not find metrics adapter ${name}.`, Adapter);
 
     return Adapter.create({ this, config });
+  },
+
+  /**
+   * Change the enableOnStart state of the given adapter to the given state
+   *
+   * @method _changeAdapterEnableState
+   * @param {String} adapterName
+   * @param {Boolean} state
+   * @return {Object} instantiated adapters
+   */
+  _changeAdapterEnableState(adapterName, state) {
+    let adapters = this._adapterOptions();
+
+    adapters.forEach((adapter) => {
+      if ( adapter.name == adapterName ) {
+        set(adapter.config, 'enableOnStart', state);
+      }
+    });
+
+    return adapters;
+  },
+
+  /**
+   * Compare the enableOnStart state of the given adapter
+   *
+   * @method _adapterEnableStateWillChange
+   * @param {String} adapterName
+   * @param {Boolean} state
+   * @return {Boolean} true if adapter enableOnStart state will change
+   */
+  _adapterEnableStateWillChange(adapterName, state) {
+    let adapterOption = this._adapterOptions().filter((adapterOption) => {
+      return adapterOption.name === adapterName;
+    })[0];
+
+    return adapterOption.config.enableOnStart !== state;
+  },
+
+  /**
+   * The current state of metricsAdapter options
+   *
+   * @method _adapterOptions
+   * @param {Void}
+   * @return {Array} adapter options
+   */
+  _adapterOptions() {
+    return getWithDefault(this, 'options.metricsAdapters', emberArray());
   },
 
   /**

--- a/tests/unit/metrics-adapters/google-analytics-test.js
+++ b/tests/unit/metrics-adapters/google-analytics-test.js
@@ -23,7 +23,19 @@ test('#identify calls ga with the right arguments', function(assert) {
   adapter.identify({
     distinctId: 123
   });
-  assert.ok(stub.calledWith('set', 'userId', 123), 'it sends the correct arguments');
+  assert.ok(stub.calledWith('GoogleAnalytics.set', 'userId', 123), 'it sends the correct arguments');
+});
+
+test('#identify calls ga with the right arguments if custom name is provided', function(assert) {
+  config = Object.assign(config, { name: 'MyCustomAnalytics' });
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window, 'ga', () => {
+    return true;
+  });
+  adapter.identify({
+    distinctId: 123
+  });
+  assert.ok(stub.calledWith('MyCustomAnalytics.set', 'userId', 123), 'it sends the correct arguments');
 });
 
 test('#trackEvent returns the correct response shape', function(assert) {

--- a/tests/unit/services/metrics-test.js
+++ b/tests/unit/services/metrics-test.js
@@ -68,29 +68,32 @@ test('#activateAdapters activates an array of adapters', function(assert) {
 
 test('#activateAdapters is idempotent', function(assert) {
   const service = this.subject({ options });
-  service.activateAdapters([
-    {
-      name: 'GoogleAnalytics',
-      environments: ['all'],
-      config: {
-        id: 'I like pie'
+  Ember.run(function() {
+    service.activateAdapters([
+      {
+        name: 'GoogleAnalytics',
+        environments: ['all'],
+        config: {
+          id: 'I like pie'
+        }
+      },
+      {
+        name: 'Mixpanel',
+        environments: ['all'],
+        config: {
+          id: 'I like pie'
+        }
+      },
+      {
+        name: 'LocalDummyAdapter',
+        environments: ['all'],
+        config: {
+          id: 'I like pie'
+        }
       }
-    },
-    {
-      name: 'Mixpanel',
-      environments: ['all'],
-      config: {
-        id: 'I like pie'
-      }
-    },
-    {
-      name: 'LocalDummyAdapter',
-      environments: ['all'],
-      config: {
-        id: 'I like pie'
-      }
-    }
-  ]);
+    ]);
+  });
+
   assert.equal(get(service, '_adapters.GoogleAnalytics.config.id'), 'UA-XXXX-Y', 'it does not override the GoogleAnalytics adapter');
   assert.equal(get(service, '_adapters.Mixpanel.config.token'), '0f76c037-4d76-4fce-8a0f-a9a8f89d1453', 'it does not override the Mixpanel adapter');
   assert.equal(get(service, '_adapters.LocalDummyAdapter.config.foo'), 'bar', 'it does not override the LocalDummyAdapter');


### PR DESCRIPTION
# Task/Issues resolved:
- https://github.com/poteto/ember-metrics/issues/134
  - Ability to turn off the Google analytics adapter anytime 
   - If you have more than one Google Analytics adapter, you can switch between them.

# TODO
- [ ] specs (doesn't have enough time right now, if anyone wants to help with that it would be great)

# How to use:

```javascript
// it can be used via serivce object from router / controller or component

// to activate adapter with enableOnStart: false flag
this.get('metrics').activateAdapter('GoogleAnalytics'); 

// to deactivate adapter with enableOnStart: true (default) flag
this.get('metrics').deactivateAdapter('GoogleAnalytics');
```

If you like to have multiple Google Analytics adapter, just add one that inherits from the default one:

```javascript
// app/metrics-adapters/google-analytics-application.js
import GoogleAnalyticsAdapter from 'ember-metrics/metrics-adapters/google-analytics';

export default GoogleAnalyticsAdapter.extend();
```

Settings:

```javascript
// config/environments.js
module.exports = function(environment) {
  var ENV = {
    ...
    metricsAdapters: [
      {
        // custom addapter name, of our second Google analytics adapter.
        name: 'GoogleAnalyticsApplication',
        environments: ['all'],
        config: {
          // new optional flag - enableOnStart true as default (it doesn't overwrite the default package behaviour
          enableOnStart: false,
          id: 'XX-XXXXX-X'
        }
      },
     ...
}
```