### PR TITLE
Exposes `boot` and `update` methods on Intercom adapter

### DIFF
--- a/addon/metrics-adapters/intercom.js
+++ b/addon/metrics-adapters/intercom.js
@@ -36,12 +36,10 @@ export default BaseAdapter.extend({
   },
 
   identify(options = {}) {
-    const { appId } = get(this, 'config');
     const compactedOptions = compact(options);
     const { distinctId } = compactedOptions;
     const props = without(compactedOptions, 'distinctId');
 
-    props.app_id = appId;
     if (distinctId) {
       props.user_id = distinctId;
     }
@@ -49,10 +47,17 @@ export default BaseAdapter.extend({
     assert(`[ember-metrics] You must pass \`distinctId\` or \`email\` to \`identify()\` when using the ${this.toString()} adapter`, props.email || props.user_id);
 
     const method = this.booted ? 'update' : 'boot';
-    if (canUseDOM) {
-      window.Intercom(method, props);
-      this.booted = true;
-    }
+
+    this[method](props);
+  },
+
+  update(props = {}) {
+    this._intercomMethod('update', props);
+  },
+
+  boot(props = {}) {
+    this._intercomMethod('boot', props);
+    this.booted = true;
   },
 
   trackEvent(options = {}) {
@@ -77,5 +82,15 @@ export default BaseAdapter.extend({
       $('script[src*="intercom"]').remove();
       delete window.Intercom;
     }
-  }
+  },
+
+  _intercomMethod(method, props) {
+    const { appId } = get(this, 'config');
+
+    props.app_id = appId;
+
+    if (canUseDOM) {
+      window.Intercom(method, props);
+    }
+  },
 });


### PR DESCRIPTION
Currently it's not possible to use the Intercom adapter without an identified/signed-in user. This exposes the `boot` method so it can be called directly in the consuming app:

```js
// Init intercom w/o a user
get(this, 'metrics').invoke('boot', 'Intercom', {});
```
This can also be accomplished in at least two other ways, but it seems odd/unexpected that this addon wouldn't allow intercom on signed out pages by default.

Alternate approaches:

1. By generating a custom adapter that extends from this addon's current Intercom adapter:

```js
import IntercomAdapter from 'ember-metrics/metrics-adapters/intercom';
import Ember from 'ember';

const {
  get,
  set,
} = Ember;

export default IntercomAdapter.extend({
  init() {
    this._super(...arguments);
    const { appId, } = get(this, 'config');
    set(this, 'appId', appId);
  },

  update(props = {}) {
    const method = get(this, 'booted') ? 'update' : 'boot';

    this._intercomMethod(method, props);
  },

  boot(props = {}) {
    this._intercomMethod('boot', props);
    set(this, 'booted', true);
  },

  _intercomMethod(method, props) {
    props.app_id = get(this, 'appId');
    window.Intercom(method, props);
  },
});
```

2. Simply calling `Intercom` on `window` e.g., 

```js
import config from './config/environment';

const {
  get,
  inject,
  run,
} = Ember;

const Router = Ember.Router.extend({
  metrics: inject.service(),
  _trackPage() {
    run.scheduleOnce('afterRender', this, () => {
      const appId = config.metricsAdapters.findBy('name', 'Intercom').config.appId;

      window.Intercom('boot', {
        app_id: appId,
      });
    });
}
```