### PR TITLE
Set fields in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,13 @@ module.exports = function(environment) {
           // Use verbose tracing of GA events
           trace: environment === 'development',
           // Ensure development env hits aren't sent to GA
-          sendHitTask: environment !== 'development'
+          sendHitTask: environment !== 'development',
+          // Sets a group of field/value pairs
+          setFields: {
+            anonymizeIp: true,
+            queueTime: 560,
+            transport: 'beacon'
+          }
         }
       },
       {

--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -21,7 +21,7 @@ export default BaseAdapter.extend({
 
   init() {
     const config = copy(get(this, 'config'));
-    const { id, sendHitTask, trace } = config;
+    const { id, sendHitTask, trace, setFields } = config;
     let { debug } = config;
 
     assert(`[ember-metrics] You must pass a valid \`id\` to the ${this.toString()} adapter`, id);
@@ -31,6 +31,7 @@ export default BaseAdapter.extend({
     if (debug) { delete config.debug; }
     if (sendHitTask) { delete config.sendHitTask; }
     if (trace) { delete config.trace; }
+    if (setFields) { delete config.setFields; }
 
     const hasOptions = isPresent(Object.keys(config));
 
@@ -55,6 +56,10 @@ export default BaseAdapter.extend({
 
       if (sendHitTask === false) {
         window.ga('set', 'sendHitTask', null);
+      }
+
+      if (setFields) {
+        window.ga('set', setFields);
       }
 
     }


### PR DESCRIPTION
I haven't found an option to [set](https://developers.google.com/analytics/devguides/collection/analyticsjs/tracker-object-reference#set) random fields by putting values to config file.