### PR TITLE
add explicit boot option for Intercom

### DIFF
--- a/addon/metrics-adapters/google-tag-manager.js
+++ b/addon/metrics-adapters/google-tag-manager.js
@@ -50,6 +50,18 @@ export default BaseAdapter.extend({
     }
   },
 
+  identify(options = {}) {
+    const compactedOptions = compact(options);
+    const dataLayer = get(this, 'dataLayer');
+    const userId = get(this, 'userId');
+    const { distinctId } = compactedOptions;
+
+    if (canUseDOM && userId !== distinctId) {
+      set(this, 'userId', distinctId);
+      window[dataLayer].push({'userId': distinctId});
+    }
+  },
+
   trackEvent(options = {}) {
     const compactedOptions = compact(options);
     const dataLayer = get(this, 'dataLayer');

--- a/addon/metrics-adapters/intercom.js
+++ b/addon/metrics-adapters/intercom.js
@@ -40,11 +40,11 @@ export default BaseAdapter.extend({
     const compactedOptions = compact(options);
     const { distinctId } = compactedOptions;
     const props = without(compactedOptions, 'distinctId');
-
     props.app_id = appId;
     if (distinctId) {
       props.user_id = distinctId;
     }
+
 
     assert(`[ember-metrics] You must pass \`distinctId\` or \`email\` to \`identify()\` when using the ${this.toString()} adapter`, props.email || props.user_id);
 
@@ -70,6 +70,20 @@ export default BaseAdapter.extend({
     const mergedOptions = assign(event, options);
 
     this.trackEvent(mergedOptions);
+  },
+
+  boot(options = {}) {
+    if (this.booted) { return; }
+
+    const { appId } = get(this, 'config');
+    const props = compact(options);
+
+    props.app_id = appId;
+
+    if (canUseDOM) {
+      window.Intercom('boot', props);
+      this.booted = true;
+    }
   },
 
   willDestroy() {

--- a/tests/unit/metrics-adapters/intercom-test.js
+++ b/tests/unit/metrics-adapters/intercom-test.js
@@ -111,3 +111,12 @@ test('#trackPage calls `Intercom()` with the right arguments', function(assert) 
   assert.ok(stub.firstCall.calledWith('trackEvent', 'page viewed', { page: '/products/1' }), 'it sends the correct arguments and options');
   assert.ok(stub.secondCall.calledWith('trackEvent', 'Page View', { page: '/products/1' }), 'it sends the correct arguments and options');
 });
+
+test('#invokeBoot calls `Intercom()` with the right arguments', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window, 'Intercom').callsFake(() => {
+    return true;
+  });
+  adapter.boot();
+  assert.ok(stub.firstCall.calledWith('boot', { app_id: 'def1abc2' }), 'it sends the correct arguments and options');
+});


### PR DESCRIPTION
Intercom allows you to boot their library without a distinctId now, in which case they'll generate one for you and leverage their guest features.

This provides a boot option which can optionally be used directly using `invoke('boot', 'Intercom', {})`