### PR TITLE
[ENHANCEMENT] add group call for segment addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,10 @@ There are 4 main methods implemented by the service, with the same argument sign
 
   For analytics services that have identification functionality.
 
+- `group([analyticsName], options)`
+
+  For analytics services that associate individual user with a group.
+
 - `alias([analyticsName], options)`
 
   For services that implement it, this method notifies the analytics service that an anonymous user now has a unique identifier.

--- a/addon/metrics-adapters/segment.js
+++ b/addon/metrics-adapters/segment.js
@@ -45,6 +45,15 @@ export default BaseAdapter.extend({
     }
   },
 
+  group(options = {}) {
+    const compactedOptions = compact(options);
+    const { groupId } = compactedOptions;
+    delete compactedOptions.groupId;
+    if(canUseDOM) {
+      window.analytics.group(groupId, compactedOptions);
+    }
+  },
+
   trackEvent(options = {}) {
     const compactedOptions = compact(options);
     const { event } = compactedOptions;

--- a/tests/unit/metrics-adapters/segment-test.js
+++ b/tests/unit/metrics-adapters/segment-test.js
@@ -75,3 +75,11 @@ test('#alias returns the correct response shape', function(assert) {
 
   assert.ok(stub.calledWith('foo', 'bar'), 'page called with default arguments');
 });
+
+test('#group returns the correct response shape', function(assert) {
+  const adapter = this.subject({ config });
+  const stub = sandbox.stub(window.analytics, 'group');
+  adapter.group({ groupId: 123 });
+
+  assert.ok(stub.calledWith(), 'group called with the correct arguments');
+});


### PR DESCRIPTION
Group call is useful if you need to associate an individual user with a group (be it a company, organization, account, project, team or whatever).