### PR TITLE
Prevent error when `sendHitTask` is `false`

### DIFF
--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -25,9 +25,9 @@ export default BaseAdapter.extend({
 
     delete config.id;
     delete config.require;
+    delete config.sendHitTask;
 
     if (debug) { delete config.debug; }
-    if (sendHitTask) { delete config.sendHitTask; }
     if (trace) { delete config.trace; }
 
     const hasOptions = isPresent(Object.keys(config));


### PR DESCRIPTION
I was getting this error when `sendHitTask` was `false` (in development)

<img width="652" alt="screen shot 2018-04-18 at 2 59 42 pm" src="https://user-images.githubusercontent.com/1645881/38962350-bb6e6fea-4321-11e8-91fb-345b5f60bb85.png">

This fixes the issue. Basically, `sendHitTask` should be either a function or `null`, nor a `Boolean`, and it shouldn't be passed to the `create` event.