### PR TITLE
add ability to set common fields on google analytics tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,12 @@ module.exports = function(environment) {
           // Ensure development env hits aren't sent to GA
           sendHitTask: environment !== 'development',
           // Specify Google Analytics plugins
-          require: ['ecommerce']
+          require: ['ecommerce'],
+          // set common field on tracker object
+          set: {
+            // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#hostname
+            hostname: 'myawesomehost.com'
+          }
         }
       },
       {

--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -18,13 +18,14 @@ export default BaseAdapter.extend({
 
   init() {
     const config = copy(get(this, 'config'));
-    const { id, sendHitTask, trace, require } = config;
+    const { id, sendHitTask, trace, require, set } = config;
     let { debug } = config;
 
     assert(`[ember-metrics] You must pass a valid \`id\` to the ${this.toString()} adapter`, id);
 
     delete config.id;
     delete config.require;
+    delete config.set;
 
     if (debug) { delete config.debug; }
     if (sendHitTask) { delete config.sendHitTask; }
@@ -59,6 +60,12 @@ export default BaseAdapter.extend({
 
       if (sendHitTask === false) {
         window.ga('set', 'sendHitTask', null);
+      }
+
+      if (set) {
+        Object.keys(set).forEach((key) => {
+          window.ga('set', key, set[key]);
+        })
       }
 
     }


### PR DESCRIPTION
Hi there 👋 I've been looking for a way to make sure the hostname was set on the google analytics tracker and wanted it to be part of the overall configuration of the addon.

I have updated the implementation and the documentation but let me know if there is anything else you think would make this better 👍 