### PR TITLE
Don't initialize mixpanel twice

### DIFF
--- a/addon/metrics-adapters/mixpanel.js
+++ b/addon/metrics-adapters/mixpanel.js
@@ -23,7 +23,7 @@ export default BaseAdapter.extend({
 
     assert(`[ember-metrics] You must pass a valid \`token\` to the ${this.toString()} adapter`, token);
 
-    if (canUseDOM) {
+    if (canUseDOM && !window.mixpanel) {
       /* eslint-disable */
       (function(e,a){if(!a.__SV){var b=window;try{var c,l,i,j=b.location,g=j.hash;c=function(a,b){return(l=a.match(RegExp(b+"=([^&]*)")))?l[1]:null};g&&c(g,"state")&&(i=JSON.parse(decodeURIComponent(c(g,"state"))),"mpeditor"===i.action&&(b.sessionStorage.setItem("_mpcehash",g),history.replaceState(i.desiredHash||"",e.title,j.pathname+j.search)))}catch(m){}var k,h;window.mixpanel=a;a._i=[];a.init=function(b,c,f){function e(b,a){var c=a.split(".");2==c.length&&(b=b[c[0]],a=c[1]);b[a]=function(){b.push([a].concat(Array.prototype.slice.call(arguments,
       0)))}}var d=a;"undefined"!==typeof f?d=a[f]=[]:f="mixpanel";d.people=d.people||[];d.toString=function(b){var a="mixpanel";"mixpanel"!==f&&(a+="."+f);b||(a+=" (stub)");return a};d.people.toString=function(){return d.toString(1)+".people (stub)"};k="disable time_event track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config reset people.set people.set_once people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(" ");


### PR DESCRIPTION
If an engine and a host app are both using mixpanel, you can get a maximum call stack error inside the mixpanel code.