### PR TITLE
Remove ‘event’ prefix for GTM parameters

### DIFF
--- a/addon/metrics-adapters/google-tag-manager.js
+++ b/addon/metrics-adapters/google-tag-manager.js
@@ -51,7 +51,7 @@ export default BaseAdapter.extend({
 
     for (let key in compactedOptions) {
       const capitalizedKey = capitalize(key);
-      gtmEvent[`event${capitalizedKey}`] = compactedOptions[key];
+      gtmEvent[`${capitalizedKey}`] = compactedOptions[key];
     }
 
     window[dataLayer].push(gtmEvent);


### PR DESCRIPTION
The event prefix causes a couple of issues for us - firstly a bit confusing to see it appear (no docs, etc). Secondly, it made integration with enhanced ecommerce in GA through GTM much more fiddly.

This quick PR removes the event prefix in GTM but at the moment is not backwards compatible - it will break in an existing app that expects the event prefix to be automatically added. If there is appetite for this to be merged, will add as a GTM config param defaulting to 'true'.

A few questions:
1) Is there a desire for this to be merged or do we want to keep the event prefix? 
2) Not sure why the event prefix was originally added - convenience?


