### PR TITLE
Remove usage of deprecated getWithDefault()

### DIFF
--- a/addon/metrics-adapters/google-tag-manager.js
+++ b/addon/metrics-adapters/google-tag-manager.js
@@ -1,6 +1,6 @@
 import { assign } from '@ember/polyfills';
 import { assert } from '@ember/debug';
-import { getWithDefault, set, get } from '@ember/object';
+import { set, get } from '@ember/object';
 import { capitalize } from '@ember/string';
 import objectTransforms from '../utils/object-transforms';
 import removeFromDOM from '../utils/remove-from-dom';
@@ -20,7 +20,7 @@ export default BaseAdapter.extend({
   init() {
     const config = get(this, 'config');
     const { id, envParams } = config;
-    const dataLayer = getWithDefault(config, 'dataLayer', 'dataLayer');
+    const dataLayer = get(config, 'dataLayer') || 'dataLayer';
     const envParamsString = envParams ? `&${envParams}`: '';
 
     assert(`[ember-metrics] You must pass a valid \`id\` to the ${this.toString()} adapter`, id);

--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -1,7 +1,7 @@
 import { assign } from '@ember/polyfills';
 import Service from '@ember/service';
 import { assert } from '@ember/debug';
-import { set, get, getWithDefault } from '@ember/object';
+import { set, get } from '@ember/object';
 import { A as emberArray, makeArray } from '@ember/array';
 import { dasherize } from '@ember/string';
 import { getOwner } from '@ember/application';
@@ -49,11 +49,11 @@ export default Service.extend({
    * @return {Void}
    */
   init() {
-    const adapters = getWithDefault(this, 'options.metricsAdapters', emberArray());
+    const adapters = get(this, 'options.metricsAdapters') || emberArray();
     const owner = getOwner(this);
     owner.registerOptionsForType('ember-metrics@metrics-adapter', { instantiate: false });
     owner.registerOptionsForType('metrics-adapter', { instantiate: false });
-    set(this, 'appEnvironment', getWithDefault(this, 'options.environment', 'development'));
+    set(this, 'appEnvironment', get(this, 'options.environment') || 'development');
     set(this, '_adapters', {});
     set(this, 'context', {});
     this.activateAdapters(adapters);


### PR DESCRIPTION
None of the values getWithDefault() was being used to get could validly be falsey, so `||` (rather than explicitly testing for `undefined`, which is what getWithDefault() does) is sufficient