### PR TITLE
Support optional Mixpanel init config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Writing your own adapters for currently unsupported analytics services is easy t
 1. `Mixpanel`
 
     - `token`: [Mixpanel token](https://mixpanel.com/help/questions/articles/where-can-i-find-my-project-token)
+    - Optionally other [config options to override](https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelinit)
 1. `GoogleTagManager`
 
     - `id`: [Container ID](https://developers.google.com/tag-manager/quickstart), e.g. `GTM-XXXX`

--- a/addon/metrics-adapters/mixpanel.js
+++ b/addon/metrics-adapters/mixpanel.js
@@ -10,7 +10,9 @@ export default class Mixpanel extends BaseAdapter {
   }
 
   init() {
-    const { token } = this.config;
+    const config = assign({ batch_requests: true }, this.config);
+    const { token } = config;
+    delete config.token;
 
     assert(`[ember-metrics] You must pass a valid \`token\` to the ${this.toString()} adapter`, token);
 
@@ -19,7 +21,7 @@ export default class Mixpanel extends BaseAdapter {
     0)))}}var e=a;"undefined"!==typeof g?e=a[g]=[]:g="mixpanel";e.people=e.people||[];e.toString=function(b){var a="mixpanel";"mixpanel"!==g&&(a+="."+g);b||(a+=" (stub)");return a};e.people.toString=function(){return e.toString(1)+".people (stub)"};l="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");
     for(h=0;h<l.length;h++)c(e,l[h]);var f="set set_once union unset remove delete".split(" ");e.get_group=function(){function a(c){b[c]=function(){call2_args=arguments;call2=[c].concat(Array.prototype.slice.call(call2_args,0));e.push([d,call2])}}for(var b={},d=["get_group"].concat(Array.prototype.slice.call(arguments,0)),c=0;c<f.length;c++)a(f[c]);return b};a._i.push([b,d,g])};a.__SV=1.2;b=c.createElement("script");b.type="text/javascript";b.async=!0;b.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?
     MIXPANEL_CUSTOM_LIB_URL:"file:"===c.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";d=c.getElementsByTagName("script")[0];d.parentNode.insertBefore(b,d)}})(document,window.mixpanel||[]);
-    mixpanel.init(token, {batch_requests:true});
+    mixpanel.init(token, config);
     /* eslint-enable */
   }
 

--- a/tests/unit/metrics-adapters/mixpanel-test.js
+++ b/tests/unit/metrics-adapters/mixpanel-test.js
@@ -88,4 +88,25 @@ module('mixpanel adapter', function(hooks) {
     assert.ok(stub.firstCall.calledWith('user@example.com', 123), 'it sends the correct arguments and options');
     assert.ok(stub.secondCall.calledWith('foo@bar.com'), 'it sends the correct arguments');
   });
+
+  test("#init supports extra configs", function (assert) {
+    const config = {
+      token: "meowmeows",
+      secure_cookie: true,
+      batch_requests: false,
+    };
+    const adapter = this.owner.factoryFor("ember-metrics@metrics-adapter:mixpanel").create({ config });
+    const init_stub = sandbox.stub(window.mixpanel, "init").callsFake(() => {
+      return true;
+    });
+    adapter.init();
+
+    assert.ok(
+      init_stub.firstCall.calledWith(config.token, {
+        secure_cookie: true,
+        batch_requests: false,
+      }),
+      "it sends the correct config options"
+    );
+  });
 });


### PR DESCRIPTION
Adds support for other optional config options for Mixpanel's `init` call.
See https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelinit for more