### PR TITLE
Allow configuring Data Processing Options in facebook-pixel

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Writing your own adapters for currently unsupported analytics services is easy t
 1. `Facebook Pixel`
 
     - `id`: [ID](https://www.facebook.com/ads/manager/pixel/facebook_pixel/?act=129849836&pid=p1)
+    - dataProcessingOptions: _optional_ An object defining the method, country and state for [data processing options](https://developers.facebook.com/docs/marketing-apis/data-processing-options/)
+    ```js
+    dataProcessingOptions: {
+      method: ['LDU'],
+      country: 1,
+      state: 1000
+    }
+    ```
 
 #### Community adapters
 
@@ -124,7 +132,12 @@ module.exports = function(environment) {
         name: 'FacebookPixel',
         environments: ['production'],
         config: {
-          id: '1234567890'
+          id: '1234567890',
+          dataProcessingOptions: {
+            method: ['LDU'],
+            country: 1,
+            state: 1000
+          }
         }
       },
 

--- a/addon/metrics-adapters/facebook-pixel.js
+++ b/addon/metrics-adapters/facebook-pixel.js
@@ -11,7 +11,7 @@ export default BaseAdapter.extend({
   },
 
   init() {
-    const { id } = this.config;
+    const { id, dataProcessingOptions } = this.config;
 
     assert(`[ember-metrics] You must pass a valid \`id\` to the ${this.toString()} adapter`, id);
 
@@ -26,6 +26,15 @@ export default BaseAdapter.extend({
     t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
     document,'script','https://connect.facebook.net/en_US/fbevents.js');
     /* eslint-enable */
+
+    if (dataProcessingOptions) {
+      const { method, country, state } = dataProcessingOptions;
+      if (method.length == 0) {
+        window.fbq('dataProcessingOptions', []);
+      } else {
+        window.fbq('dataProcessingOptions', method, country, state);
+      }
+    }
 
     window.fbq('init', id);
 


### PR DESCRIPTION
Facebook released a Limitited Data Use feature, to aid with CCPA
compliance. This commit allows enabling (or disabling) the LDU via
configuration.