### PR TITLE
Remove can-use-dom export

### DIFF
--- a/app/utils/can-use-dom.js
+++ b/app/utils/can-use-dom.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-metrics/utils/can-use-dom';


### PR DESCRIPTION
This util was remove in #175 but the app export wasn't.