### PR TITLE
segment: Add `addSource/DestinationMiddleware()` methods

### DIFF
--- a/addon/metrics-adapters/segment.js
+++ b/addon/metrics-adapters/segment.js
@@ -40,6 +40,8 @@ export default class Segment extends BaseAdapter {
 
     // A list of the methods in Analytics.js to stub.
     analytics.methods = [
+      'addSourceMiddleware',
+      'addDestinationMiddleware',
       'trackSubmit',
       'trackClick',
       'trackLink',


### PR DESCRIPTION
These methods are described on https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/middleware/, and are necessary for certain tracking operations. Without this change the methods will not be exposed on the `analytics` global and won't be useable.

