### PR TITLE
Updated Azure App Insights `trackEvent` method to allow for custom properties

### DIFF
--- a/addon/metrics-adapters/azure-app-insights.js
+++ b/addon/metrics-adapters/azure-app-insights.js
@@ -21,14 +21,13 @@ export default class AzureAppInsightsAdapter extends BaseAdapter {
     /* eslint-enable */
   }
 
-  trackEvent({ action, category, name, value } = {}) {
+  trackEvent(properties = {}) {
+    const { name } = properties;
+    delete properties.name;
+
     window.appInsights.trackEvent({
       name,
-      properties: {
-        category,
-        action,
-        value,
-      },
+      properties,
     });
   }
 

--- a/tests/unit/metrics-adapters/azure-app-insights-test.js
+++ b/tests/unit/metrics-adapters/azure-app-insights-test.js
@@ -29,6 +29,7 @@ module("azure-app-insights adapter", function (hooks) {
       action: "click",
       name: "submit button",
       value: 1,
+      customKey: "I'm custom!"
     });
 
     assert.ok(
@@ -38,6 +39,7 @@ module("azure-app-insights adapter", function (hooks) {
           action: "click",
           category: "login",
           value: 1,
+          customKey: "I'm custom!"
         },
       }),
       "it sends the correct arguments"


### PR DESCRIPTION
This allows users to send additional data to app insights if they need to.