### PR TITLE
Simplify Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,6 @@ If you are using an app built with the [Ember Octane Blueprint](https://github.c
 ```js
 // app/routes/application.js
 import Route from '@ember/routing/route';
-import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class ApplicationRoute extends Route {


### PR DESCRIPTION
Given import is not necessary for the snippet to work. Reader has to unnecessarily mentally parse what is happening and whether they need to add that line or not.