### PR TITLE
[refactor] default GA key as public class field

### DIFF
--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -8,7 +8,7 @@ import classic from 'ember-classic-decorator';
 
 @classic
 export default class GoogleAnalytics extends BaseAdapter {
-  gaSendKey = null;
+  gaSendKey = 'send';
 
   toStringExtension() {
     return 'GoogleAnalytics';
@@ -17,7 +17,10 @@ export default class GoogleAnalytics extends BaseAdapter {
   init() {
     const config = { ...this.config };
     const { id, sendHitTask, trace, require, debug, trackerName } = config;
-    this.gaSendKey = trackerName ? trackerName + '.send' : 'send';
+
+    if (trackerName) {
+      this.gaSendKey = `${trackerName}.send`;
+    }
 
     assert(
       `[ember-metrics] You must pass a valid \`id\` to the ${this.toString()} adapter`,


### PR DESCRIPTION
Declares GA adapter key as a [public class field](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#field_declarations) for better readability.