### PR TITLE
Refactor canUseMetrics

### DIFF
--- a/addon/metrics-adapters/facebook-pixel.js
+++ b/addon/metrics-adapters/facebook-pixel.js
@@ -3,7 +3,6 @@ import removeFromDOM from '../utils/remove-from-dom';
 import BaseAdapter from './base';
 import { assert } from '@ember/debug';
 import classic from 'ember-classic-decorator';
-import canUseMetrics from '../utils/can-use-metrics';
 
 @classic
 export default class FacebookPixel extends BaseAdapter {
@@ -19,7 +18,7 @@ export default class FacebookPixel extends BaseAdapter {
       id
     );
 
-    if (window.fbq || !canUseMetrics) {
+    if (window.fbq) {
       return;
     }
 
@@ -57,19 +56,19 @@ export default class FacebookPixel extends BaseAdapter {
     }
     delete compactedOptions.event;
 
-    if (window.fbq && canUseMetrics) {
+    if (window.fbq) {
       window.fbq('track', event, compactedOptions);
     }
   }
 
   trackPage(options = {}) {
-    if (window.fbq && canUseMetrics) {
+    if (window.fbq) {
       window.fbq('track', 'PageView', options);
     }
   }
 
   willDestroy() {
-    if (window.fbq && canUseMetrics) {
+    if (window.fbq) {
       removeFromDOM('script[src*="fbevents.js"]');
 
       delete window.fbq;

--- a/addon/metrics-adapters/google-analytics.js
+++ b/addon/metrics-adapters/google-analytics.js
@@ -5,7 +5,6 @@ import { compact } from '../utils/object-transforms';
 import removeFromDOM from '../utils/remove-from-dom';
 import BaseAdapter from './base';
 import classic from 'ember-classic-decorator';
-import canUseMetrics from '../utils/can-use-metrics';
 
 @classic
 export default class GoogleAnalytics extends BaseAdapter {
@@ -36,10 +35,6 @@ export default class GoogleAnalytics extends BaseAdapter {
     delete config.trackerName;
 
     const hasOptions = isPresent(Object.keys(config));
-
-    if (!canUseMetrics) {
-      return;
-    }
 
     this._injectScript(debug);
 
@@ -74,9 +69,7 @@ export default class GoogleAnalytics extends BaseAdapter {
     const compactedOptions = compact(options);
     const { distinctId } = compactedOptions;
 
-    if (canUseMetrics) {
-      window.ga('set', 'userId', distinctId);
-    }
+    window.ga('set', 'userId', distinctId);
   }
 
   trackEvent(options = {}) {
@@ -102,9 +95,7 @@ export default class GoogleAnalytics extends BaseAdapter {
     const event = { ...sendEvent, ...gaEvent };
     const gaSendKey = this.gaSendKey;
 
-    if (canUseMetrics) {
-      window.ga(gaSendKey, event);
-    }
+    window.ga(gaSendKey, event);
 
     return event;
   }
@@ -114,25 +105,21 @@ export default class GoogleAnalytics extends BaseAdapter {
     const sendEvent = { hitType: 'pageview' };
     const event = { ...sendEvent, ...compactedOptions };
 
-    if (canUseMetrics) {
-      for (let key in compactedOptions) {
-        // eslint-disable-next-line
-        if (compactedOptions.hasOwnProperty(key)) {
-          window.ga('set', key, compactedOptions[key]);
-        }
+    for (let key in compactedOptions) {
+      // eslint-disable-next-line
+      if (compactedOptions.hasOwnProperty(key)) {
+        window.ga('set', key, compactedOptions[key]);
       }
-      const gaSendKey = this.gaSendKey;
-      window.ga(gaSendKey, event);
     }
+    const gaSendKey = this.gaSendKey;
+    window.ga(gaSendKey, event);
 
     return event;
   }
 
   willDestroy() {
-    if (canUseMetrics) {
-      removeFromDOM('script[src*="google-analytics"]');
+    removeFromDOM('script[src*="google-analytics"]');
 
-      delete window.ga;
-    }
+    delete window.ga;
   }
 }

--- a/addon/metrics-adapters/google-tag-manager.js
+++ b/addon/metrics-adapters/google-tag-manager.js
@@ -4,7 +4,6 @@ import { compact } from '../utils/object-transforms';
 import removeFromDOM from '../utils/remove-from-dom';
 import BaseAdapter from './base';
 import classic from 'ember-classic-decorator';
-import canUseMetrics from '../utils/can-use-metrics';
 
 @classic
 export default class GoogleTagManager extends BaseAdapter {
@@ -25,9 +24,7 @@ export default class GoogleTagManager extends BaseAdapter {
 
     this.dataLayer = dataLayer || 'dataLayer';
 
-    if (canUseMetrics) {
-      this._injectScript(id, envParamsString);
-    }
+    this._injectScript(id, envParamsString);
   }
 
   // prettier-ignore
@@ -59,9 +56,7 @@ export default class GoogleTagManager extends BaseAdapter {
       gtmEvent[`event${capitalizedKey}`] = compactedOptions[key];
     }
 
-    if (canUseMetrics) {
-      window[dataLayer].push(gtmEvent);
-    }
+    window[dataLayer].push(gtmEvent);
 
     return gtmEvent;
   }
@@ -75,18 +70,14 @@ export default class GoogleTagManager extends BaseAdapter {
 
     const pageEvent = { ...sendEvent, ...compactedOptions };
 
-    if (canUseMetrics) {
-      window[dataLayer].push(pageEvent);
-    }
+    window[dataLayer].push(pageEvent);
 
     return pageEvent;
   }
 
   willDestroy() {
-    if (canUseMetrics) {
-      removeFromDOM('script[src*="gtm.js"]');
+    removeFromDOM('script[src*="gtm.js"]');
 
-      delete window.dataLayer;
-    }
+    delete window.dataLayer;
   }
 }

--- a/addon/metrics-adapters/intercom.js
+++ b/addon/metrics-adapters/intercom.js
@@ -3,7 +3,6 @@ import { compact, without } from '../utils/object-transforms';
 import removeFromDOM from '../utils/remove-from-dom';
 import BaseAdapter from './base';
 import classic from 'ember-classic-decorator';
-import canUseMetrics from '../utils/can-use-metrics';
 
 @classic
 export default class Intercom extends BaseAdapter {
@@ -21,9 +20,7 @@ export default class Intercom extends BaseAdapter {
       appId
     );
 
-    if (canUseMetrics) {
-      this._injectScript(appId);
-    }
+    this._injectScript(appId);
   }
 
   /* eslint-disable */
@@ -53,10 +50,8 @@ export default class Intercom extends BaseAdapter {
 
     const method = this.booted ? 'update' : 'boot';
 
-    if (canUseMetrics) {
-      window.Intercom(method, props);
-      this.booted = true;
-    }
+    window.Intercom(method, props);
+    this.booted = true;
   }
 
   trackEvent(options = {}) {
@@ -64,9 +59,7 @@ export default class Intercom extends BaseAdapter {
     const { event = 'unspecified-event' } = compactedOptions;
     const props = without(compactedOptions, 'event');
 
-    if (canUseMetrics) {
-      window.Intercom('trackEvent', event, props);
-    }
+    window.Intercom('trackEvent', event, props);
   }
 
   trackPage(options = {}) {
@@ -77,10 +70,8 @@ export default class Intercom extends BaseAdapter {
   }
 
   willDestroy() {
-    if (canUseMetrics) {
-      removeFromDOM('script[src*="intercom"]');
+    removeFromDOM('script[src*="intercom"]');
 
-      delete window.Intercom;
-    }
+    delete window.Intercom;
   }
 }

--- a/addon/metrics-adapters/mixpanel.js
+++ b/addon/metrics-adapters/mixpanel.js
@@ -3,7 +3,6 @@ import { without, compact, isPresent } from '../utils/object-transforms';
 import removeFromDOM from '../utils/remove-from-dom';
 import BaseAdapter from './base';
 import classic from 'ember-classic-decorator';
-import canUseMetrics from '../utils/can-use-metrics';
 
 @classic
 export default class Mixpanel extends BaseAdapter {
@@ -21,10 +20,8 @@ export default class Mixpanel extends BaseAdapter {
       token
     );
 
-    if (canUseMetrics) {
-      this._injectScript();
-      window.mixpanel.init(token, config);
-    }
+    this._injectScript();
+    window.mixpanel.init(token, config);
   }
 
   /* eslint-disable */
@@ -42,13 +39,11 @@ export default class Mixpanel extends BaseAdapter {
     const { distinctId } = compactedOptions;
     const props = without(compactedOptions, 'distinctId');
 
-    if (canUseMetrics) {
-      if (isPresent(props)) {
-        window.mixpanel.identify(distinctId);
-        window.mixpanel.people.set(props);
-      } else {
-        window.mixpanel.identify(distinctId);
-      }
+    if (isPresent(props)) {
+      window.mixpanel.identify(distinctId);
+      window.mixpanel.people.set(props);
+    } else {
+      window.mixpanel.identify(distinctId);
     }
   }
 
@@ -57,12 +52,10 @@ export default class Mixpanel extends BaseAdapter {
     const { event } = compactedOptions;
     const props = without(compactedOptions, 'event');
 
-    if (canUseMetrics) {
-      if (isPresent(props)) {
-        window.mixpanel.track(event, props);
-      } else {
-        window.mixpanel.track(event);
-      }
+    if (isPresent(props)) {
+      window.mixpanel.track(event, props);
+    } else {
+      window.mixpanel.track(event);
     }
   }
 
@@ -77,20 +70,16 @@ export default class Mixpanel extends BaseAdapter {
     const compactedOptions = compact(options);
     const { alias, original } = compactedOptions;
 
-    if (canUseMetrics) {
-      if (original) {
-        window.mixpanel.alias(alias, original);
-      } else {
-        window.mixpanel.alias(alias);
-      }
+    if (original) {
+      window.mixpanel.alias(alias, original);
+    } else {
+      window.mixpanel.alias(alias);
     }
   }
 
   willDestroy() {
-    if (canUseMetrics) {
-      removeFromDOM('script[src*="mixpanel"]');
+    removeFromDOM('script[src*="mixpanel"]');
 
-      delete window.mixpanel;
-    }
+    delete window.mixpanel;
   }
 }

--- a/addon/metrics-adapters/piwik.js
+++ b/addon/metrics-adapters/piwik.js
@@ -2,7 +2,6 @@ import { assert } from '@ember/debug';
 import removeFromDOM from '../utils/remove-from-dom';
 import BaseAdapter from './base';
 import classic from 'ember-classic-decorator';
-import canUseMetrics from '../utils/can-use-metrics';
 
 @classic
 export default class Piwik extends BaseAdapter {
@@ -18,9 +17,7 @@ export default class Piwik extends BaseAdapter {
       piwikUrl && siteId
     );
 
-    if (canUseMetrics) {
-      this._injectScript(piwikUrl, siteId);
-    }
+    this._injectScript(piwikUrl, siteId);
   }
 
   // prettier-ignore
@@ -35,35 +32,27 @@ export default class Piwik extends BaseAdapter {
   }
 
   identify(options = {}) {
-    if (canUseMetrics) {
-      window._paq.push(['setUserId', options.userId]);
-    }
+    window._paq.push(['setUserId', options.userId]);
   }
 
   trackEvent(options = {}) {
-    if (canUseMetrics) {
-      window._paq.push([
-        'trackEvent',
-        options.category,
-        options.action,
-        options.name,
-        options.value,
-      ]);
-    }
+    window._paq.push([
+      'trackEvent',
+      options.category,
+      options.action,
+      options.name,
+      options.value,
+    ]);
   }
 
   trackPage(options = {}) {
-    if (canUseMetrics) {
-      window._paq.push(['setCustomUrl', options.page]);
-      window._paq.push(['trackPageView', options.title]);
-    }
+    window._paq.push(['setCustomUrl', options.page]);
+    window._paq.push(['trackPageView', options.title]);
   }
 
   willDestroy() {
-    if (canUseMetrics) {
-      removeFromDOM('script[src*="piwik"]');
+    removeFromDOM('script[src*="piwik"]');
 
-      delete window._paq;
-    }
+    delete window._paq;
   }
 }

--- a/addon/metrics-adapters/segment.js
+++ b/addon/metrics-adapters/segment.js
@@ -3,7 +3,6 @@ import removeFromDOM from '../utils/remove-from-dom';
 import { compact } from '../utils/object-transforms';
 import BaseAdapter from './base';
 import classic from 'ember-classic-decorator';
-import canUseMetrics from '../utils/can-use-metrics';
 
 @classic
 export default class Segment extends BaseAdapter {
@@ -19,10 +18,6 @@ export default class Segment extends BaseAdapter {
       `[ember-metrics] You must pass a valid \`key\` to the ${this.toString()} adapter`,
       segmentKey
     );
-
-    if (!canUseMetrics) {
-      return;
-    }
 
     // start of segment loading snippet, taken here:
     // https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/#step-1-copy-the-snippet
@@ -120,12 +115,10 @@ export default class Segment extends BaseAdapter {
     const compactedOptions = compact(options);
     const { alias, original } = compactedOptions;
 
-    if (canUseMetrics) {
-      if (original) {
-        window.analytics.alias(alias, original);
-      } else {
-        window.analytics.alias(alias);
-      }
+    if (original) {
+      window.analytics.alias(alias, original);
+    } else {
+      window.analytics.alias(alias);
     }
   }
 
@@ -134,9 +127,7 @@ export default class Segment extends BaseAdapter {
     const { distinctId } = compactedOptions;
     delete compactedOptions.distinctId;
 
-    if (canUseMetrics) {
-      window.analytics.identify(distinctId, compactedOptions);
-    }
+    window.analytics.identify(distinctId, compactedOptions);
   }
 
   trackEvent(options = {}) {
@@ -144,9 +135,7 @@ export default class Segment extends BaseAdapter {
     const { event } = compactedOptions;
     delete compactedOptions.event;
 
-    if (canUseMetrics) {
-      window.analytics.track(event, compactedOptions);
-    }
+    window.analytics.track(event, compactedOptions);
   }
 
   trackPage(options = {}) {
@@ -154,16 +143,12 @@ export default class Segment extends BaseAdapter {
     const { page } = compactedOptions;
     delete compactedOptions.page;
 
-    if (canUseMetrics) {
-      window.analytics.page(page, compactedOptions);
-    }
+    window.analytics.page(page, compactedOptions);
   }
 
   willDestroy() {
-    if (canUseMetrics) {
-      removeFromDOM('script[src*="segment.com"]');
+    removeFromDOM('script[src*="segment.com"]');
 
-      delete window.analytics;
-    }
+    delete window.analytics;
   }
 }

--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -27,13 +27,17 @@ export default class Metrics extends Service {
   context = {};
 
   /**
-   * Indicates whether calls to the service will be forwarded to the adapters
+   * Indicates whether calls to the service will be forwarded to the adapters.
+   * This is determined by investigating the user's doNotTrack settings.
+   *
+   * Note that the doNotTrack specification is deprecated, and could stop
+   * working at any minute. As such should this feature not be detected we
+   * presume tracking is permitted.
    *
    * @property enabled
    * @type Boolean
-   * @default true
    */
-  enabled = true;
+  enabled = typeof navigator !== 'undefined' && navigator.doNotTrack !== '1';
 
   /**
    * Information about the active adapters from environment.js
@@ -80,6 +84,10 @@ export default class Metrics extends Service {
    * @return {Object} instantiated adapters
    */
   activateAdapters(adapterOptions = []) {
+    if (!this.enabled) {
+      return;
+    }
+
     const adaptersForEnv = this._adaptersForEnv(adapterOptions);
     const activeAdapters = {};
 

--- a/addon/utils/can-use-metrics.js
+++ b/addon/utils/can-use-metrics.js
@@ -1,7 +1,0 @@
-const canUseMetrics =
-  typeof window !== 'undefined' &&
-  window.doNotTrack !== '1' &&
-  typeof navigator !== 'undefined' &&
-  navigator.doNotTrack !== '1';
-
-export default canUseMetrics;

--- a/app/utils/can-use-metrics.js
+++ b/app/utils/can-use-metrics.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-metrics/utils/can-use-metrics';


### PR DESCRIPTION
By moving the check to the service layer we can ensure user defined
adapters, and all future adapters, take advantage of this feature and
that we needn't litter the code with this check.

Note that doNotTrack is a deprecated feature, and thus checking to see
if a user has opted in isn't sufficient -- we also have to ensure the
absence of this feature (should it be removed) doesn't break our code
as well.