### PR TITLE
[chore] remove exposing private utils to `app`

### DIFF
--- a/app/utils/object-transforms.js
+++ b/app/utils/object-transforms.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-metrics/-private/utils/object-transforms';

--- a/app/utils/remove-from-dom.js
+++ b/app/utils/remove-from-dom.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-metrics/-private/utils/remove-from-dom';

--- a/tests/unit/utils/remove-from-dom-test.js
+++ b/tests/unit/utils/remove-from-dom-test.js
@@ -1,4 +1,4 @@
-import removeFromDOM from '../../../utils/remove-from-dom';
+import removeFromDOM from 'ember-metrics/-private/utils/remove-from-dom';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';


### PR DESCRIPTION
Recent refactoring work created `/addon/-private/utils` directory for non-public utils. these utils are still currently being exposed to the consuming application via the `app` folder. to keep things consistent, we should remove that point of exposure.

- removes `/app/utils` folder
  - internal references maintain connection to `/addon/-private/utils` as before
- update `remove-from-dom` test import to point to `/-private/utils` directly rather than relative path import