### PR TITLE
Remove deprecated Amplitude behaviour

### DIFF
--- a/addon/metrics-adapters/amplitude.js
+++ b/addon/metrics-adapters/amplitude.js
@@ -5,7 +5,7 @@ import {
   hasOwnProperties,
 } from 'ember-metrics/-private/utils/object-transforms';
 import removeFromDOM from 'ember-metrics/-private/utils/remove-from-dom';
-import { assert, deprecate } from '@ember/debug';
+import { assert } from '@ember/debug';
 
 export default class AmplitudeMetricsAdapter extends BaseAdapter {
   toStringExtension() {
@@ -80,19 +80,6 @@ export default class AmplitudeMetricsAdapter extends BaseAdapter {
     }
 
     window.amplitude.getInstance().identify(this._identity);
-
-    deprecate(
-      'Future versions of the AmplitudeAdapter will no longer issue an "Identify" event upon identifying. If you wish to retain this behaviour you will need to track this event yourself.',
-      false,
-      {
-        id: 'ember-metrics.issue-278',
-        for: 'ember-metrics',
-        since: '1.3.2',
-        until: '2.0.0',
-      }
-    );
-
-    window.amplitude.getInstance().logEvent('Identify');
   }
 
   trackEvent(options = {}) {

--- a/tests/unit/metrics-adapters/amplitude-test.js
+++ b/tests/unit/metrics-adapters/amplitude-test.js
@@ -43,10 +43,6 @@ module('amplitude adapter', function (hooks) {
     assert
       .spy(this.instanceStub.identify)
       .calledWith([this.identityStub], 'it sends the correct user identity');
-
-    assert
-      .spy(this.instanceStub.logEvent)
-      .calledWith(['Identify'], 'it calls a logEvent for "Identify"');
   });
 
   test('#trackEvent sends the correct request shape', function (assert) {


### PR DESCRIPTION
Removes an automatic "Identify" event when calling #identify. If you
wish to retain this behaviour you should...

```javascript
metricsService.identify(...);
metricsService.trackEvent({ event: "Identify" });
```