### PR TITLE
fix(metrics service): replace object iterator with `Object.values`

### DIFF
--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -225,9 +225,7 @@ export default class Metrics extends Service {
    * @return {Void}
    */
   willDestroy() {
-    for (let adapter of this._adapters) {
-      adapter.destroy();
-    }
+    Object.values(this._adapters).forEach((adapter) => adapter.destroy());
   }
 }
 

--- a/tests/acceptance/lifecycle-test.ts
+++ b/tests/acceptance/lifecycle-test.ts
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+module('Acceptance | lifecycle', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('initialization and teardown in an ember app', async function (assert) {
+    await visit('/');
+    assert.strictEqual(currentURL(), '/');
+  });
+});


### PR DESCRIPTION
Looks like the _adapters = {}; doesn't support native iteration since it's a plain object.

From MDN:
> In JavaScript, Objects are not iterable unless they implement the iterable protocol. Therefore, you cannot use for…of to iterate over the properties of an object.

Fixes #373

### Lifecycle test

I've added a very basic acceptance test – which fails before this patch is applied. I think it can be helpful to catch lifecycle bugs like this in the future. Happy to split into a separate PR if necessary.