### PR TITLE
Apply missing spread operator to method calls

### DIFF
--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -170,19 +170,19 @@ export default class Metrics extends Service {
   }
 
   identify() {
-    this.invoke('identify', arguments);
+    this.invoke('identify', ...arguments);
   }
 
   alias() {
-    this.invoke('alias', arguments);
+    this.invoke('alias', ...arguments);
   }
 
   trackEvent() {
-    this.invoke('trackEvent', arguments);
+    this.invoke('trackEvent', ...arguments);
   }
 
   trackPage() {
-    this.invoke('trackPage', arguments);
+    this.invoke('trackPage', ...arguments);
   }
 
   /**


### PR DESCRIPTION
The metrics service refactor (https://github.com/adopted-ember-addons/ember-metrics/pull/297) dropped the argument spreading from the convenience methods which call `invoke()` so they're currently broken as of the 1.4 release.
