### PR TITLE
Reexport the built-in MetricsAdapters from the app folder

### DIFF
--- a/app/metrics-adapters/amplitude.js
+++ b/app/metrics-adapters/amplitude.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-metrics/metrics-adapters/amplitude';

--- a/app/metrics-adapters/azure-app-insights.js
+++ b/app/metrics-adapters/azure-app-insights.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-metrics/metrics-adapters/azure-app-insights';

--- a/app/metrics-adapters/base.js
+++ b/app/metrics-adapters/base.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-metrics/metrics-adapters/base';

--- a/app/metrics-adapters/facebook-pixel.js
+++ b/app/metrics-adapters/facebook-pixel.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-metrics/metrics-adapters/facebook-pixel';

--- a/app/metrics-adapters/google-analytics.js
+++ b/app/metrics-adapters/google-analytics.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-metrics/metrics-adapters/google-analytics';

--- a/app/metrics-adapters/google-tag-manager.js
+++ b/app/metrics-adapters/google-tag-manager.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-metrics/metrics-adapters/google-tag-manager';

--- a/app/metrics-adapters/intercom.js
+++ b/app/metrics-adapters/intercom.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-metrics/metrics-adapters/intercom';

--- a/app/metrics-adapters/mixpanel.js
+++ b/app/metrics-adapters/mixpanel.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-metrics/metrics-adapters/mixpanel';

--- a/app/metrics-adapters/pendo.js
+++ b/app/metrics-adapters/pendo.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-metrics/metrics-adapters/pendo';

--- a/app/metrics-adapters/piwik.js
+++ b/app/metrics-adapters/piwik.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-metrics/metrics-adapters/piwik';

--- a/app/metrics-adapters/segment.js
+++ b/app/metrics-adapters/segment.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-metrics/metrics-adapters/segment';

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -76,7 +76,7 @@ module.exports = async function () {
         },
       },
       embroiderSafe(),
-      embroiderOptimized({ allowedToFail: true }),
+      embroiderOptimized(),
     ],
   };
 };

--- a/index.js
+++ b/index.js
@@ -79,6 +79,10 @@ module.exports = {
     );
   },
 
+  treeForApp: function (tree) {
+    return this.filterAdapters(tree, new RegExp('^metrics-adapters/', 'i'));
+  },
+
   filterAdapters: function (tree, regex) {
     var whitelisted = this.whitelisted;
 


### PR DESCRIPTION
This ensures that Embroider doesn't strip them out of the build when `staticAddonTrees` is enabled. We still strip out unused adapters manually.

Closes #316 