### PR TITLE
Minor Segment improvements (custom proxy domain and updated snippet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Writing your own adapters for currently unsupported analytics services is easy t
 1. `Segment`
 
    - `key`: [Segment key](https://segment.com/docs/libraries/analytics.js/quickstart/)
+   - `proxyDomain`: _optional_ [Custom domain proxy](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/custom-proxy/)
 
 1. `Piwik`
 
@@ -429,6 +430,7 @@ module.exports = function (environment) {
 We're grateful to these wonderful contributors who've contributed to `ember-metrics`:
 
 [//]: contributor-faces
+
 <a href="https://github.com/jherdman"><img src="https://avatars.githubusercontent.com/u/3300?v=4" title="jherdman" width="80" height="80"></a>
 <a href="https://github.com/poteto"><img src="https://avatars.githubusercontent.com/u/1390709?v=4" title="poteto" width="80" height="80"></a>
 <a href="https://github.com/kellyselden"><img src="https://avatars.githubusercontent.com/u/602423?v=4" title="kellyselden" width="80" height="80"></a>
@@ -463,7 +465,6 @@ We're grateful to these wonderful contributors who've contributed to `ember-metr
 ## Contributing
 
 See the [Contributing](CONTRIBUTING.md) guide for details.
-
 
 ## License
 

--- a/addon/metrics-adapters/segment.js
+++ b/addon/metrics-adapters/segment.js
@@ -11,6 +11,7 @@ export default class Segment extends BaseAdapter {
   install() {
     const config = { ...this.config };
     const segmentKey = config.key;
+    const proxyDomain = config.proxyDomain || 'https://cdn.segment.com';
 
     assert(
       `[ember-metrics] You must pass a valid \`key\` to the ${this.toString()} adapter`,
@@ -87,8 +88,7 @@ export default class Segment extends BaseAdapter {
       const script = document.createElement('script');
       script.type = 'text/javascript';
       script.async = true;
-      script.src =
-        'https://cdn.segment.com/analytics.js/v1/' + key + '/analytics.min.js';
+      script.src = `${proxyDomain}/analytics.js/v1/${key}/analytics.min.js`;
 
       // Insert our script next to the first script element.
       const first = document.getElementsByTagName('script')[0];

--- a/addon/metrics-adapters/segment.js
+++ b/addon/metrics-adapters/segment.js
@@ -18,9 +18,7 @@ export default class Segment extends BaseAdapter {
     );
 
     // start of segment loading snippet, taken here:
-    // https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/#step-1-copy-the-snippet
-
-    /* eslint-disable no-console */
+    // https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/#step-2-copy-the-segment-snippet
 
     // Create a queue, but don't obliterate an existing one!
     let analytics = (window.analytics = window.analytics || []);
@@ -28,7 +26,7 @@ export default class Segment extends BaseAdapter {
     // If the real analytics.js is already on the page return.
     if (analytics.initialize) return;
 
-    // If the snippet was invoked already show an error
+    // If the snippet was invoked already show an error.
     if (analytics.invoked) {
       if (window.console && console.error) {
         console.error('Segment snippet included twice.');
@@ -42,8 +40,6 @@ export default class Segment extends BaseAdapter {
 
     // A list of the methods in Analytics.js to stub.
     analytics.methods = [
-      'addSourceMiddleware',
-      'addDestinationMiddleware',
       'trackSubmit',
       'trackClick',
       'trackLink',
@@ -60,15 +56,18 @@ export default class Segment extends BaseAdapter {
       'once',
       'off',
       'on',
+      'addSourceMiddleware',
+      'addIntegrationMiddleware',
+      'setAnonymousId',
+      'addDestinationMiddleware',
     ];
-
     // Define a factory to create stubs. These are placeholders
     // for methods in Analytics.js so that you never have to wait
     // for it to load to actually record data. The `method` is
     // stored as the first argument, so we can replay the data.
     analytics.factory = function (method) {
       return function () {
-        var args = Array.prototype.slice.call(arguments);
+        let args = Array.prototype.slice.call(arguments);
         args.unshift(method);
         analytics.push(args);
         return analytics;
@@ -76,8 +75,8 @@ export default class Segment extends BaseAdapter {
     };
 
     // For each of our methods, generate a queueing stub.
-    for (var i = 0; i < analytics.methods.length; i++) {
-      var key = analytics.methods[i];
+    for (let i = 0; i < analytics.methods.length; i++) {
+      const key = analytics.methods[i];
       analytics[key] = analytics.factory(key);
     }
 
@@ -85,26 +84,25 @@ export default class Segment extends BaseAdapter {
     // and that will be sure to only ever load it once.
     analytics.load = function (key, options) {
       // Create an async script element based on your key.
-      var script = document.createElement('script');
+      const script = document.createElement('script');
       script.type = 'text/javascript';
       script.async = true;
       script.src =
         'https://cdn.segment.com/analytics.js/v1/' + key + '/analytics.min.js';
 
       // Insert our script next to the first script element.
-      var first = document.getElementsByTagName('script')[0];
+      const first = document.getElementsByTagName('script')[0];
       first.parentNode.insertBefore(script, first);
       analytics._loadOptions = options;
     };
+    analytics._writeKey = segmentKey;
 
     // Add a version to keep track of what's in the wild.
-    analytics.SNIPPET_VERSION = '4.1.0';
+    analytics.SNIPPET_VERSION = '4.15.2';
 
     // Load Analytics.js with your key, which will automatically
-    // load the tools you've enabled for your account.
+    // load the tools you've enabled for your account. Boosh!
     analytics.load(segmentKey);
-
-    /* eslint-enable no-console */
 
     // end of segment loading snippet
   }


### PR DESCRIPTION
Hello 👋 
Segment is about to ditch Analytics.js Classic and appears to need a most recent version of the snippet https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/upgrade-to-ajs2/ which is the purpose of that PR.
I also took the liberty to add a new option which would allow to use a custom proxy domain: https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/custom-proxy/
Let me know if I can help in any way :)
Thanks!