### PR TITLE
remove `event` prefix from top-level keys in GoogleTagManager adapter

### DIFF
--- a/addon/metrics-adapters/google-tag-manager.js
+++ b/addon/metrics-adapters/google-tag-manager.js
@@ -1,5 +1,4 @@
-import { assert, deprecate } from '@ember/debug';
-import { capitalize } from '@ember/string';
+import { assert } from '@ember/debug';
 import { compact } from 'ember-metrics/-private/utils/object-transforms';
 import removeFromDOM from 'ember-metrics/-private/utils/remove-from-dom';
 import BaseAdapter from './base';
@@ -44,30 +43,10 @@ export default class GoogleTagManager extends BaseAdapter {
 
   trackEvent(options = {}) {
     const compactedOptions = compact(options);
-    const dataLayer = this.dataLayer;
-    const gtmEvent = { event: compactedOptions['event'] };
 
-    deprecate(
-      'Future versions of the GoogleTagManagerAdapter will no longer prefix top-level dataLayer keys with `event`. If you wish to retain this behaviour you will need to override the adapter and prefix the keys yourself.',
-      false,
-      {
-        id: 'ember-metrics.issue-438',
-        for: 'ember-metrics',
-        since: '1.5.0',
-        until: '2.0.0',
-      }
-    );
+    window[this.dataLayer].push(compactedOptions);
 
-    delete compactedOptions['event'];
-
-    for (let key in compactedOptions) {
-      const capitalizedKey = capitalize(key);
-      gtmEvent[`event${capitalizedKey}`] = compactedOptions[key];
-    }
-
-    window[dataLayer].push(gtmEvent);
-
-    return gtmEvent;
+    return compactedOptions;
   }
 
   trackPage(options = {}) {

--- a/tests/unit/metrics-adapters/google-tag-manager-test.js
+++ b/tests/unit/metrics-adapters/google-tag-manager-test.js
@@ -16,33 +16,38 @@ module('google-tag-manager adapter', function (hooks) {
     this.adapter.uninstall();
   });
 
-  test('#trackEvent returns the correct response shape', function (assert) {
+  test('#trackEvent pushes the event into the dataLayer', function (assert) {
     const adapter = new GoogleTagManager(this.config);
     this.adapter = adapter;
     adapter.install();
 
-    sinon.stub(window, 'dataLayer').value({ push() {} });
+    const events = [];
+    sinon.stub(window, 'dataLayer').value({
+      push(e) {
+        events.push(e);
+      },
+    });
 
-    const result = adapter.trackEvent({
+    const eventPayload = {
       event: 'click-button',
       category: 'button',
       action: 'click',
       label: 'nav buttons',
       value: 4,
-    });
-
-    const expectedResult = {
-      event: 'click-button',
-      eventCategory: 'button',
-      eventAction: 'click',
-      eventLabel: 'nav buttons',
-      eventValue: 4,
     };
+
+    const result = adapter.trackEvent(eventPayload);
 
     assert.deepEqual(
       result,
-      expectedResult,
+      eventPayload,
       'it sends the correct response shape'
+    );
+
+    assert.deepEqual(
+      events[0],
+      eventPayload,
+      'it pushes the event into the dataLayer'
     );
   });
 


### PR DESCRIPTION
This is a follow up to [this PR](https://github.com/adopted-ember-addons/ember-metrics/pull/444) which added a deprecation for the prefixing behavior in the GTM adapter. This PR removes the actual code as well as the deprecation, and updates the relevant tests. It also adds an assertion that actually tests the `dataLayer.push` functionality in the adapter.

[Original Issue](https://github.com/adopted-ember-addons/ember-metrics/issues/438)