### PR TITLE
Add warning that ember-metrics won't activate if do not track is true

### DIFF
--- a/addon/services/metrics.js
+++ b/addon/services/metrics.js
@@ -65,6 +65,10 @@ export default class Metrics extends Service {
     this._options = { metricsAdapters, environment };
     this.appEnvironment = environment;
     this.activateAdapters(metricsAdapters);
+
+    if (navigator !== 'undefined' && navigator.doNotTrack == '1' && environment !== 'production') {
+      console.warn('[ember-metrics] Browser settings specify do not track. No metrics will be sent to any adapter.')
+    }
   }
 
   /**


### PR DESCRIPTION
It took me much longer than it should have to figure out why ember-metrics wasn't enabling. This warning would've helped me out a bunch, and hopefully it helps someone else down the road.