### PR TITLE
drop support for Ember < 3.28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,8 +170,7 @@ jobs:
       fail-fast: true
       matrix:
         ember-try-scenario: [
-            ember-lts-3.20,
-            ember-lts-3.24,
+            ember-lts-3.28,
             # ember-release,
             # ember-beta,
             # ember-canary,

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ ember install ember-metrics
 
 ## Compatibility
 
-- Ember.js v3.20 or above
-- Ember CLI v3.20 or above
+- Ember.js v3.28 or above
+- Ember CLI v3.28 or above
 - Node.js v18 or above
 
 ## Configuration

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,20 +8,10 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.20',
+        name: 'ember-lts-3.28',
         npm: {
           devDependencies: {
-            'ember-qunit': '6.0.0',
-            'ember-source': '~3.20.5',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.24',
-        npm: {
-          devDependencies: {
-            'ember-qunit': '6.0.0',
-            'ember-source': '~3.24.3',
+            'ember-source': '~3.28.0',
           },
         },
       },


### PR DESCRIPTION
This drops support for Ember 3.20 - 3.27. Version 3.28, which is the last version of the 3.x release cycle, is still supported.

It was proposed by @SergeAstapov in https://github.com/adopted-ember-addons/ember-metrics/pull/547#discussion_r1861452235:

> we may bump support for 3.28+ which should simplify CI and should not affect many (if any) users as 3.20 -> 3.28 upgrade should be pretty simple

This is a breaking change. We are preparing a new major currently. So it is a good time to land it.