### PR TITLE
Fix @ember/string resolution issues by depending on ember-auto-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "broccoli-funnel": "^3.0.2",
+    "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-typescript": "^5.1.1"
   },
@@ -86,7 +87,6 @@
     "@typescript-eslint/parser": "^5.57.1",
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^8.0.1",
-    "ember-auto-import": "^2.6.3",
     "ember-cli": "~4.12.3",
     "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.2.0",


### PR DESCRIPTION
`@ember/string` is a v2 addon. Resolving the peer dependency on it not working reliable without having a dependency on `ember-auto-import`. We faced issues already when adding it as a peer dependency in #547. The issues magically disappeared when upgrading the project with Ember CLI 4.12 blueprints. But they occurred again when migrating from yarn v1 to PNPM. Likely consumers will face similar issues unless ember-metrics depends on ember-auto-import.

This is a breaking change.