### PR TITLE
Bump the versions of the GoogleTagManagerAdapter deprecation

### DIFF
--- a/addon/metrics-adapters/google-tag-manager.js
+++ b/addon/metrics-adapters/google-tag-manager.js
@@ -53,8 +53,8 @@ export default class GoogleTagManager extends BaseAdapter {
       {
         id: 'ember-metrics.issue-438',
         for: 'ember-metrics',
-        since: '1.5.0',
-        until: '2.0.0',
+        since: '2.0.0',
+        until: '3.0.0',
       }
     );
 


### PR DESCRIPTION
The since wasn't correct since it was only released in 2.0.0-beta.1 and the until needs to be until the next major